### PR TITLE
Add new Redis Enterprise Operator Helm chart releases

### DIFF
--- a/_index.yaml
+++ b/_index.yaml
@@ -1,0 +1,76 @@
+apiVersion: v1
+entries:
+  redis-enterprise-operator:
+  - apiVersion: v2
+    appVersion: 7.6.2-1
+    created: "2024-12-02T14:50:20.747808132Z"
+    description: A Helm chart for Redis Enterprise Operator for Kubernetes
+    digest: 2e46a415c6e772d225cba3b8e47f139d06dd9b47feed0e52d827ba3c1525d100
+    home: https://redis.io
+    icon: https://redis.io/wp-content/uploads/2024/04/Logotype.svg
+    keywords:
+    - redis
+    - database
+    maintainers:
+    - name: Redis
+      url: https://redis.com/company/contact/
+    name: redis-enterprise-operator
+    type: application
+    urls:
+    - https://github.com/oshribr/helm-release/releases/download/redis-enterprise-operator-7.6.2-1/redis-enterprise-operator-7.6.2-1.tgz
+    version: 7.6.2-1
+  - apiVersion: v2
+    appVersion: 7.4.2-21
+    created: "2024-12-02T14:47:38.223902828Z"
+    description: A Helm chart for Redis Enterprise Operator for Kubernetes
+    digest: 8ae5ff806e9f90c07b8aad1f76281cd551c92d069721793c58cd8aa80152425f
+    home: https://redis.io
+    icon: https://redis.io/wp-content/uploads/2024/04/Logotype.svg
+    keywords:
+    - redis
+    - database
+    maintainers:
+    - name: Redis
+      url: https://redis.com/company/contact/
+    name: redis-enterprise-operator
+    type: application
+    urls:
+    - https://github.com/oshribr/helm-release/releases/download/redis-enterprise-operator-7.4.2-21/redis-enterprise-operator-7.4.2-21.tgz
+    version: 7.4.2-21
+  - apiVersion: v2
+    appVersion: 7.4.2-15
+    created: "2024-12-02T14:45:30.666305778Z"
+    description: A Helm chart for Redis Enterprise Operator for Kubernetes
+    digest: 02328f90ba8e5ce1b3be4cd2fdd487415c8683ded00f340f9cbd92d01078a97a
+    home: https://redis.io
+    icon: https://redis.io/wp-content/uploads/2024/04/Logotype.svg
+    keywords:
+    - redis
+    - database
+    maintainers:
+    - name: Redis
+      url: https://redis.com/company/contact/
+    name: redis-enterprise-operator
+    type: application
+    urls:
+    - https://github.com/oshribr/helm-release/releases/download/redis-enterprise-operator-7.4.2-15/redis-enterprise-operator-7.4.2-15.tgz
+    version: 7.4.2-15
+  - apiVersion: v2
+    appVersion: 7.2.4-12
+    created: "2024-12-02T14:53:41.553910391Z"
+    description: A Helm chart for Redis Enterprise Operator for Kubernetes
+    digest: 7b24fe92b9f1cdc4d2b241ea1b060b197db1ac89e9eca6e56a4644da255d216a
+    home: https://redis.io
+    icon: https://redis.io/wp-content/uploads/2024/04/Logotype.svg
+    keywords:
+    - redis
+    - database
+    maintainers:
+    - name: Redis
+      url: https://redis.com/company/contact/
+    name: redis-enterprise-operator
+    type: application
+    urls:
+    - https://github.com/oshribr/helm-release/releases/download/redis-enterprise-operator-7.2.4-12/redis-enterprise-operator-7.2.4-12.tgz
+    version: 7.2.4-12
+generated: "2024-12-02T14:53:41.553929607Z"


### PR DESCRIPTION
## Summary
This change adds new releases of the Redis Enterprise Operator Helm chart for different versions of the Redis Enterprise software.

## Details
- Added new entries in the `_index.yaml` file for Redis Enterprise Operator Helm chart releases:
  - Version 7.6.2-1
  - Version 7.4.2-21
  - Version 7.4.2-15
  - Version 7.2.4-12
- Each entry includes information about the chart, such as the version, app version, creation date, description, maintainer details, and download URL.
- This allows users to easily install and manage different versions of the Redis Enterprise Operator on Kubernetes using Helm.